### PR TITLE
Switch to mqtt Module from async-mqtt for Improved Maintenance and Performance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+### Breaking Changes
+
+- Switched from `async-mqtt` to `mqtt` module for improved maintenance and performance.
+- Updated method names to use asynchronous versions:
+- Replace `subscribe()`, `publish()`, `unsubscribe()`, and `end()` with `await subscribeAsync()`, `await publishAsync()`, `await unsubscribeAsync()`, and `await endAsync()` respectively.
+  - The previous methods are blocking in the `mqtt` module.
+
 ### Added
 
 - runs latest versions of prettier and eslint

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,11 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - runs latest versions of prettier and eslint
 - node 22.x added to matrix tests
+- uses mqtt module instead of async-mqtt
 
 ### Fixed
 
 - issue with coverage:ci tests, running on node 22 fixes it
 - wrong setting on env var for online tests
+- does not depend on inflight module anymore (avoids potencial memory leaks)
 
 ## 0.2.5 - 2023-05-10
 

--- a/README.md
+++ b/README.md
@@ -4,11 +4,18 @@
 [![Coverage Status](https://coveralls.io/repos/github/dmanto/mojo-plugin-mqtt-helper/badge.svg?branch=main)](https://coveralls.io/github/dmanto/mojo-plugin-mqtt-helper?branch=main)
 [![npm](https://img.shields.io/npm/v/mojo-plugin-mqtt-helper.svg)](https://www.npmjs.com/package/mojo-plugin-mqtt-helper)
 
-A mojo.js plugin to add an MQTT helper, wrapped over async-mqtt module.
+A mojo.js plugin to add an MQTT helper, wrapped over mqtt module.
+
+## Important notes for existing users
+
+**v0.4.0** (09/2024)
+
+- The module does not use `async-mqtt` anymore, and just returns an MqttClient Object
+- As a result, methods `subscribe`, `unsuscribe`, `publish` and `end` are now blocking methods, so you want to use `subscribeAsync`, `unsuscribeAsync`, `publishAsync` and `endAsync` instead (please see the examples).
 
 ## API
 
-The API is the same as [async-mqtt](https://github.com/mqttjs/async-mqtt#api) client.
+The API is the same as [mqtt](https://github.com/mqttjs/mqtt#api) client.
 
 ## Example
 
@@ -23,10 +30,10 @@ app.get('/', async ctx => {
   const client = await ctx.mqttClient('mqtt://test.mosquitto.org');
   client.on('message', async (topic, message) => {
     await ctx.render({text: `Received message on topic ${topic}: ${message}`});
-    await client.end();
+    await client.endAsync();
   });
-  await client.subscribe('mojojs/test/#');
-  await client.publish('mojojs/test/hello/Channel', 'Hello world!');
+  await client.subscribeAsync('mojojs/test/#');
+  await client.publishAsync('mojojs/test/hello/Channel', 'Hello world!');
 });
 app.start();
 ```

--- a/examples/chat.js
+++ b/examples/chat.js
@@ -12,12 +12,13 @@ app
       client.on('message', async (_topic, message) => {
         await ws.send(message.toString());
       });
-      await client.subscribe('mojojs/mojochat/#');
+      await client.subscribeAsync('mojojs/mojochat/#');
       for await (const data of ws) {
-        await client.publish('mojojs/mojochat/channel', data);
+        await client.publishAsync('mojojs/mojochat/channel', data);
       }
       ws.on('close', async () => {
-        await client.end();
+        await client.unsubscribeAsync('mojojs/mojochat/#');
+        await client.endAsync();
       });
     });
   })

--- a/examples/hello.js
+++ b/examples/hello.js
@@ -8,9 +8,10 @@ app.get('/', async ctx => {
   const client = await ctx.mqttClient('mqtt://test.mosquitto.org');
   client.on('message', async (topic, message) => {
     await ctx.render({text: `Received message on topic ${topic}: ${message}`});
-    await client.end();
+    await client.unsubscribeAsync('mojojs/test/#');
+    await client.endAsync();
   });
-  await client.subscribe('mojojs/test/#');
-  await client.publish('mojojs/test/hello/Channel', 'Hello world!');
+  await client.subscribeAsync('mojojs/test/#');
+  await client.publishAsync('mojojs/test/hello/Channel', 'Hello world!');
 });
 app.start();

--- a/package.json
+++ b/package.json
@@ -71,6 +71,6 @@
   },
   "dependencies": {
     "@mojojs/core": "^1.26.6",
-    "async-mqtt": "^2.6.3"
+    "mqtt": "^5.10.1"
   }
 }

--- a/src/mojo-plugin-mqtt-helper.ts
+++ b/src/mojo-plugin-mqtt-helper.ts
@@ -1,18 +1,19 @@
 import type {MojoApp} from '@mojojs/core/lib/types';
-import {connectAsync, type MqttClient, type IClientOptions} from 'mqtt';
+import {connectAsync, type MqttClient} from 'mqtt';
 
 /**
  * mqttPlugin.
  * @param app
  */
 export default function mqttPlugin(app: MojoApp) {
-  app.addHelper('mqttClient', (_ctx, brokerUrl?, opts?, allowRetries?) => {
-    return connectAsync(brokerUrl !== undefined ? brokerUrl : 'mqtt://localhost:1833', opts, allowRetries);
+  app.addHelper('mqttClient', (_ctx, ...args: Parameters<typeof connectAsync>) => {
+    const [brokerUrl, ...rest] = args;
+    return connectAsync(brokerUrl !== undefined ? brokerUrl : 'mqtt://localhost:1833', ...rest);
   });
 }
 
 declare module '@mojojs/core/lib/types' {
   interface MojoContext {
-    mqttClient: (brokerUrl?: string, opts?: IClientOptions, allowRetries?: boolean) => Promise<MqttClient>;
+    mqttClient: (...args: Parameters<typeof connectAsync> | []) => Promise<MqttClient>;
   }
 }

--- a/src/mojo-plugin-mqtt-helper.ts
+++ b/src/mojo-plugin-mqtt-helper.ts
@@ -1,19 +1,18 @@
 import type {MojoApp} from '@mojojs/core/lib/types';
-import pkg, {type AsyncMqttClient, type IClientOptions} from 'async-mqtt';
-const {connectAsync} = pkg;
+import {connectAsync, type MqttClient, type IClientOptions} from 'mqtt';
 
 /**
  * mqttPlugin.
  * @param app
  */
 export default function mqttPlugin(app: MojoApp) {
-  app.addHelper('mqttClient', (_ctx, brokerUrl?: any, opts?: IClientOptions, allowRetries?: boolean) => {
-    return connectAsync(brokerUrl, opts, allowRetries);
+  app.addHelper('mqttClient', (_ctx, brokerUrl?, opts?, allowRetries?) => {
+    return connectAsync(brokerUrl !== undefined ? brokerUrl : 'mqtt://localhost:1833', opts, allowRetries);
   });
 }
 
 declare module '@mojojs/core/lib/types' {
   interface MojoContext {
-    mqttClient: (brokerUrl?: any, opts?: IClientOptions, allowRetries?: boolean) => Promise<AsyncMqttClient>;
+    mqttClient: (brokerUrl?: string, opts?: IClientOptions, allowRetries?: boolean) => Promise<MqttClient>;
   }
 }

--- a/test-d/mojo-plugin-mqtt-helper.test-d.ts
+++ b/test-d/mojo-plugin-mqtt-helper.test-d.ts
@@ -1,4 +1,4 @@
-import type {AsyncMqttClient} from 'async-mqtt';
+import type {MqttClient} from 'mqtt';
 import mqttPlugin from '../lib/mojo-plugin-mqtt-helper';
 import mojo from '@mojojs/core';
 import {expectType} from 'tsd';
@@ -6,5 +6,5 @@ import {expectType} from 'tsd';
 const app = mojo();
 app.plugin(mqttPlugin);
 const ctx = app.newMockContext();
-expectType<Promise<AsyncMqttClient>>(ctx.mqttClient());
-expectType<Promise<AsyncMqttClient>>(ctx.mqttClient('mqtt://test.mosquitto.org', {clientId: 'someClientId'}, true));
+expectType<Promise<MqttClient>>(ctx.mqttClient());
+expectType<Promise<MqttClient>>(ctx.mqttClient('mqtt://test.mosquitto.org', {clientId: 'someClientId'}, true));

--- a/test/broker-connection.js
+++ b/test/broker-connection.js
@@ -14,12 +14,13 @@ t.test('BrokerConnection', skip, async t => {
 
   app.get('/subscribe-n-wait', async ctx => {
     const client = await ctx.mqttClient(process.env.MQTT_TEST_ONLINE);
-    await client.subscribe(fooTopic);
+    await client.subscribeAsync(fooTopic);
     client.on('message', async (topic, message) => {
       await ctx.render({text: `topic: ${topic}, message: ${message}`});
-      await client.end();
+      await client.unsubscribeAsync(fooTopic);
+      await client.endAsync();
     });
-    await client.publish(fooTopic, 'It works!');
+    await client.publishAsync(fooTopic, 'It works!');
   });
 
   const ua = await app.newTestUserAgent({tap: t});


### PR DESCRIPTION
- Replaces the `async-mqtt` dependency with the `mqtt` module, which is better maintained and more stable.
- Addresses reported memory leak issues associated with the `insight` module, which was previously used.
- **Breaking Changes**:
  - You should now use `await subscribeAsync()`, `await publishAsync()`, `await unsubscribeAsync()`, and `await endAsync()` methods instead of the current `subscribe()`, `publish()`, `unsubscribe()`, and `end()` methods, as the latter are blocking in the `mqtt` module.
